### PR TITLE
Feat/store menu paging and status

### DIFF
--- a/src/main/java/com/sparta/aiverification/ai/controller/AIController.java
+++ b/src/main/java/com/sparta/aiverification/ai/controller/AIController.java
@@ -4,8 +4,8 @@ import com.sparta.aiverification.ai.dto.AIRequestDto;
 import com.sparta.aiverification.ai.dto.AIResponseDto;
 import com.sparta.aiverification.ai.service.AIService;
 import com.sparta.aiverification.user.security.UserDetailsImpl;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +28,7 @@ public class AIController {
   public AIController(AIService aiService){
     this.aiService = aiService;
   }
+
   // 1. AI 생성
   @PostMapping
   public AIResponseDto createAI(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody AIRequestDto aiRequestDto) {
@@ -35,14 +37,20 @@ public class AIController {
 
   // 2. AI 목록 조회
   @GetMapping
-  public List<AIResponseDto> createAIList() {
-    return aiService.getAIList();
+  public Page<AIResponseDto> getAIList(
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+    return aiService.getAIList(page - 1, size, sortBy, isAsc, userDetailsImpl.getUser());
   }
 
   // 3. AI 정보 조회
   @GetMapping("/{aiId}")
-  public AIResponseDto getAI(@PathVariable("aiId") Long aiId) {
-    return aiService.getAI(aiId);
+  public AIResponseDto getAI(@PathVariable("aiId") Long aiId,
+      @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+    return aiService.getAI(aiId, userDetailsImpl.getUser());
   }
 
   // 4. AI 수정

--- a/src/main/java/com/sparta/aiverification/ai/repository/AIRepository.java
+++ b/src/main/java/com/sparta/aiverification/ai/repository/AIRepository.java
@@ -1,8 +1,15 @@
 package com.sparta.aiverification.ai.repository;
 
 import com.sparta.aiverification.ai.entity.AI;
+import com.sparta.aiverification.user.entity.User;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AIRepository extends JpaRepository<AI, Long> {
+
+  Page<AI> findAllByUser(User user, Pageable pageable);
+  AI findByMenu(UUID menuId);
 
 }

--- a/src/main/java/com/sparta/aiverification/ai/service/AIService.java
+++ b/src/main/java/com/sparta/aiverification/ai/service/AIService.java
@@ -23,7 +23,7 @@ public class AIService {
   private final AIRepository aiRepository;
   private final MenuRepository menuRepository;
 
-  private static void userValidate(User user) {
+  private static void isNotCustomer(User user) {
     // validation
     if (user.getRole() == UserRoleEnum.CUSTOMER) {
       throw new IllegalArgumentException("UNAUTHORIZED ACCESS");
@@ -33,7 +33,7 @@ public class AIService {
   @Transactional
   public AIResponseDto createAI(User user, AIRequestDto aiRequestDto) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     Menu menu = menuRepository.findById(aiRequestDto.getMenuId())
         .orElseThrow(() -> new NoSuchElementException("Menu with ID " + aiRequestDto.getMenuId() + " not found"));
@@ -65,7 +65,7 @@ public class AIService {
   @Transactional
   public AIResponseDto updateAI(Long aiId, User user, AIRequestDto aiRequestDto) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     AI ai = aiRepository.findById(aiId).orElseThrow(NoSuchElementException::new);
     ai.update(aiRequestDto);
@@ -74,7 +74,7 @@ public class AIService {
   @Transactional
   public void deleteAI(Long aiId, User user) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     AI ai = aiRepository.findById(aiId).orElseThrow(NoSuchElementException::new);
      ai.delete(user.getId());

--- a/src/main/java/com/sparta/aiverification/ai/service/AIService.java
+++ b/src/main/java/com/sparta/aiverification/ai/service/AIService.java
@@ -6,14 +6,19 @@ import com.sparta.aiverification.ai.entity.AI;
 import com.sparta.aiverification.ai.repository.AIRepository;
 import com.sparta.aiverification.menu.entity.Menu;
 import com.sparta.aiverification.menu.repository.MenuRepository;
+import com.sparta.aiverification.store.entity.Store;
+import com.sparta.aiverification.store.repository.StoreRepository;
 import com.sparta.aiverification.user.entity.User;
 import com.sparta.aiverification.user.enums.UserRoleEnum;
 import jakarta.transaction.Transactional;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
@@ -22,6 +27,7 @@ import org.springframework.stereotype.Service;
 public class AIService {
   private final AIRepository aiRepository;
   private final MenuRepository menuRepository;
+  private final StoreRepository storeRepository;
 
   private static void isNotCustomer(User user) {
     // validation
@@ -30,10 +36,22 @@ public class AIService {
     }
   }
 
+  private void isCorrectOWNER(User user, UUID menuId){
+
+    if(user.getRole() == UserRoleEnum.OWNER){
+      Store store = storeRepository.findByMenuId(menuId);
+
+      if(user.getId() !=  store.getUserId()){
+        throw new IllegalArgumentException("UNAUTHORIZED ACCESS");
+      }
+    }
+  }
   @Transactional
   public AIResponseDto createAI(User user, AIRequestDto aiRequestDto) {
     // validation
     isNotCustomer(user);
+    // OWNER : 본인 가게 메뉴에 대해서만 가능
+    isCorrectOWNER(user, aiRequestDto.getMenuId());
 
     Menu menu = menuRepository.findById(aiRequestDto.getMenuId())
         .orElseThrow(() -> new NoSuchElementException("Menu with ID " + aiRequestDto.getMenuId() + " not found"));
@@ -47,18 +65,34 @@ public class AIService {
     return new AIResponseDto(ai);
   }
 
-  public List<AIResponseDto> getAIList() {
-    List<AIResponseDto> aiResponseDtoList = new ArrayList<>();
+  public Page<AIResponseDto> getAIList(int page, int size, String sortBy, boolean isAsc,User user) {
 
-    List<AI> aiList = aiRepository.findAll();
-    for(AI ai : aiList){
-      aiResponseDtoList.add(new AIResponseDto(ai));
+    // validation
+    isNotCustomer(user);
+
+    // 페이징 처리
+    Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+    Sort sort = Sort.by(direction, sortBy);
+    Pageable pageable =  PageRequest.of(page, size, sort);
+
+    Page<AI> aiList;
+
+    // OWNER : 본인 가게 목록만 조회
+    if(user.getRole() == UserRoleEnum.OWNER){
+      aiList = aiRepository.findAllByUser(user, pageable);
     }
-    return aiResponseDtoList;
+    else{
+      aiList = aiRepository.findAll(pageable);
+    }
+    return aiList.map(AIResponseDto::new);
   }
 
-  public AIResponseDto getAI(Long aiId) {
+  public AIResponseDto getAI(Long aiId, User user) {
+    isNotCustomer(user);
+
     AI ai = aiRepository.findById(aiId).orElseThrow(NoSuchElementException::new);
+    isCorrectOWNER(user, ai.getMenu().getId());
+
     return new AIResponseDto(ai);
   }
 
@@ -67,16 +101,22 @@ public class AIService {
     // validation
     isNotCustomer(user);
 
+
     AI ai = aiRepository.findById(aiId).orElseThrow(NoSuchElementException::new);
+    isCorrectOWNER(user, ai.getMenu().getId());
+
     ai.update(aiRequestDto);
     return new AIResponseDto(ai);
   }
+
   @Transactional
   public void deleteAI(Long aiId, User user) {
     // validation
     isNotCustomer(user);
 
     AI ai = aiRepository.findById(aiId).orElseThrow(NoSuchElementException::new);
-     ai.delete(user.getId());
+    isCorrectOWNER(user, ai.getMenu().getId());
+
+    ai.delete(user.getId());
   }
 }

--- a/src/main/java/com/sparta/aiverification/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/aiverification/category/service/CategoryService.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CategoryService {
 
-  private static void userValidate(User user) {
+  private static void isAdmin(User user) {
     // validation
     if (user.getRole() != UserRoleEnum.MASTER && user.getRole() != UserRoleEnum.MANAGER) {
       throw new IllegalArgumentException("UNAUTHORIZED ACCESS");
@@ -31,7 +31,7 @@ public class CategoryService {
   @Transactional
   public CategoryResponseDto createCategory(User user, CategoryRequestDto categoryRequestDto) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Category category = Category.builder().name(categoryRequestDto.getCategoryName()).build();
     categoryRepository.save(category);
@@ -55,7 +55,7 @@ public class CategoryService {
   @Transactional
   public CategoryResponseDto updateCategory(Long categoryId, User user, CategoryRequestDto categoryRequestDto) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Category category = categoryRepository.findById(categoryId).orElseThrow(NoSuchElementException::new);
     category.update(categoryRequestDto.getCategoryName());
@@ -65,7 +65,7 @@ public class CategoryService {
   @Transactional
   public void deleteCategory(Long categoryId, User user) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Category category = categoryRepository.findById(categoryId).orElseThrow(NoSuchElementException::new);
     categoryRepository.deleteById(categoryId);

--- a/src/main/java/com/sparta/aiverification/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/aiverification/menu/controller/MenuController.java
@@ -49,8 +49,9 @@ public class MenuController{
 
   // 3. 메뉴 정보 조회
   @GetMapping("/{menuId}")
-  public MenuResponseDto getMenuById(@PathVariable UUID menuId) {
-    return menuService.getMenuById(menuId);
+  public MenuResponseDto getMenuById(@PathVariable UUID menuId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return menuService.getMenuById(menuId, userDetails.getUser());
   }
 
   // 4. 메뉴 수정

--- a/src/main/java/com/sparta/aiverification/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/aiverification/menu/controller/MenuController.java
@@ -4,9 +4,9 @@ import com.sparta.aiverification.menu.dto.MenuRequestDto;
 import com.sparta.aiverification.menu.dto.MenuResponseDto;
 import com.sparta.aiverification.menu.service.MenuService;
 import com.sparta.aiverification.user.security.UserDetailsImpl;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,8 +37,14 @@ public class MenuController{
 
   // 2. 메뉴 목록 조회
   @GetMapping
-  public List<MenuResponseDto> getAllMenus() {
-    return menuService.getAllMenus();
+  public Page<MenuResponseDto> getAllMenus(
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    return menuService.getAllMenus(page-1, size, sortBy, isAsc, userDetails.getUser());
   }
 
   // 3. 메뉴 정보 조회

--- a/src/main/java/com/sparta/aiverification/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/aiverification/menu/repository/MenuRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
-//  List<Menu> findByName(String menuName);
-  Page<Menu> findByStoreId(UUID storeId, Pageable pageable);
-
+  //  List<Menu> findByName(String menuName);
+  Page<Menu> findMenusByStoreAndStatus(UUID storeId, Boolean status, Pageable pageable);
+  Page<Menu> findMenusByStore(UUID storeId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/aiverification/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/aiverification/menu/repository/MenuRepository.java
@@ -1,12 +1,13 @@
 package com.sparta.aiverification.menu.repository;
 
 import com.sparta.aiverification.menu.entity.Menu;
-import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
 //  List<Menu> findByName(String menuName);
-  List<Menu> findByStoreId(UUID storeId);
+  Page<Menu> findByStoreId(UUID storeId, Pageable pageable);
 
 }

--- a/src/main/java/com/sparta/aiverification/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/aiverification/menu/service/MenuService.java
@@ -26,7 +26,7 @@ public class MenuService {
   private final MenuRepository menuRepository;
   private final StoreRepository storeRepository;
 
-  private static void userValidate(User user) {
+  private static void isNotCustomer(User user) {
     // validation
     if (user.getRole() == UserRoleEnum.CUSTOMER) {
       throw new IllegalArgumentException("UNAUTHORIZED ACCESS");
@@ -37,7 +37,7 @@ public class MenuService {
   @Transactional
   public MenuResponseDto createMenu(MenuRequestDto menuRequestDto, User user) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     Store store = storeRepository.findById(menuRequestDto.getStoreId())
         .orElseThrow(() -> new RuntimeException("Store not found"));
@@ -111,7 +111,7 @@ public class MenuService {
   @Transactional
   public MenuResponseDto updateMenu(UUID menuId, User user, MenuRequestDto menuRequestDto) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     Store store = storeRepository.findById(menuRequestDto.getStoreId())
         .orElseThrow(() -> new RuntimeException("Store not found"));
@@ -132,7 +132,7 @@ public class MenuService {
   @Transactional
   public void deleteMenu(UUID menuId, User user) {
     // validation
-    userValidate(user);
+    isNotCustomer(user);
 
     Menu menu = menuRepository.findById(menuId)
         .orElseThrow(() -> new RuntimeException("Menu not found"));

--- a/src/main/java/com/sparta/aiverification/region/service/RegionService.java
+++ b/src/main/java/com/sparta/aiverification/region/service/RegionService.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RegionService {
   private final RegionRepository regionRepository;
 
-  private static void userValidate(User user) {
+  private static void isAdmin(User user) {
     // validation
     if (user.getRole() != UserRoleEnum.MASTER && user.getRole() != UserRoleEnum.MANAGER) {
       throw new IllegalArgumentException("UNAUTHORIZED ACCESS");
@@ -30,7 +30,7 @@ public class RegionService {
   @Transactional
   public RegionResponseDto createRegion(User user, RegionRequestDto regionRequestDto) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Region region = Region.builder().name(regionRequestDto.getRegionName()).build();
     regionRepository.save(region);
@@ -55,7 +55,7 @@ public class RegionService {
   @Transactional
   public RegionResponseDto updateRegion(Long regionId, User user, RegionRequestDto regionRequestDto) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Region region = regionRepository.findById(regionId).orElseThrow(NoSuchElementException::new);
     region.update(regionRequestDto.getRegionName());
@@ -65,7 +65,7 @@ public class RegionService {
   @Transactional
   public void deleteRegion(Long regionId, User user) {
     // validation
-    userValidate(user);
+    isAdmin(user);
 
     Region region = regionRepository.findById(regionId).orElseThrow(NoSuchElementException::new);
 

--- a/src/main/java/com/sparta/aiverification/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/aiverification/store/controller/StoreController.java
@@ -6,9 +6,9 @@ import com.sparta.aiverification.store.dto.StoreRequestDto;
 import com.sparta.aiverification.store.dto.StoreResponseDto;
 import com.sparta.aiverification.store.service.StoreService;
 import com.sparta.aiverification.user.security.UserDetailsImpl;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,6 +33,7 @@ public class StoreController {
     this.storeService = storeService;
     this.menuService = menuService;
   }
+
   // 0. 가게 생성
   @PostMapping
   public StoreResponseDto createStore(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody StoreRequestDto storeRequestDto) {
@@ -40,20 +42,39 @@ public class StoreController {
 
   // 1.1 가게 목록 조회
   @GetMapping
-  public List<StoreResponseDto> getAllStores() {
-    return storeService.getAllStores();
+  public Page<StoreResponseDto> getAllStores(
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    return storeService.getAllStores(page-1, size, sortBy, isAsc, userDetails.getUser());
   }
 
   // 1.2 카테고리별 가게 목록 조회
   @GetMapping("/categories/{categoryId}")
-  public List<StoreResponseDto> getAllStoresByCategoryId(@PathVariable("categoryId") Long categoryId) {
-    return storeService.getAllStoresByCategoryId(categoryId);
+  public Page<StoreResponseDto> getAllStoresByCategoryId(
+      @PathVariable("categoryId") Long categoryId,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return storeService.getAllStoresByCategoryId(categoryId, page-1, size, sortBy, isAsc, userDetails.getUser());
   }
 
   // 1.3 지역 별 가게 목록 조회
   @GetMapping("/regions/{regionId}")
-  public List<StoreResponseDto> getAllStoresByRegionId(@PathVariable("regionId") Long regionId) {
-    return storeService.getAllStoresByRegionId(regionId);
+  public Page<StoreResponseDto> getAllStoresByRegionId(
+      @PathVariable("regionId") Long regionId,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    return storeService.getAllStoresByRegionId(regionId, page-1, size, sortBy, isAsc, userDetails.getUser());
   }
 
   // 2. 가게 정보 조회
@@ -64,8 +85,14 @@ public class StoreController {
 
   // 3. 가게의 상품 목록 조회
   @GetMapping("/{storeId}/menus")
-  public List<MenuResponseDto> getMenusByStore(@PathVariable("storeId") UUID storeId) {
-    return menuService.getMenusByStoreId(storeId);
+  public Page<MenuResponseDto> getMenusByStore(
+      @PathVariable("storeId") UUID storeId,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return menuService.getMenusByStoreId(storeId, page-1, size, sortBy, isAsc, userDetails.getUser());
   }
 
   // 4. 가게 정보 수정

--- a/src/main/java/com/sparta/aiverification/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/aiverification/store/controller/StoreController.java
@@ -79,8 +79,8 @@ public class StoreController {
 
   // 2. 가게 정보 조회
   @GetMapping("/{storeId}")
-  public StoreResponseDto getStoreById(@PathVariable("storeId") UUID storeId) {
-    return storeService.getStoreById(storeId);
+  public StoreResponseDto getStoreById(@PathVariable("storeId") UUID storeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return storeService.getStoreById(storeId, userDetails.getUser());
   }
 
   // 3. 가게의 상품 목록 조회

--- a/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
@@ -15,4 +15,7 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
   Page<Store> findAllByUserAAndCategory(User user, Long categoryId, Pageable pageable);
   Page<Store> findAllByUserAAndRegion(User user, Long regionId, Pageable pageable);
 
+  Page<Store> findAllByStatus(Boolean status, Pageable pageable);
+  Page<Store> findAllByCategoryAndStatus(Long categoryId, boolean b, Pageable pageable);
+  Page<Store> findAllByRegionAndStatus(Long regionId, boolean b, Pageable pageable);
 }

--- a/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
@@ -1,11 +1,18 @@
 package com.sparta.aiverification.store.repository;
 
 import com.sparta.aiverification.store.entity.Store;
-import java.util.List;
+import com.sparta.aiverification.user.entity.User;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
-  List<Store> findAllByCategoryId(Long categoryId);
-  List<Store> findAllByRegionId(Long regionId);
+  Page<Store> findAllByCategoryId(Long categoryId, Pageable pageable);
+  Page<Store> findAllByRegionId(Long regionId, Pageable pageable);
+
+  Page<Store> findAllByUser(User user, Pageable pageable);
+  Page<Store> findAllByUserAAndCategory(User user, Long categoryId, Pageable pageable);
+  Page<Store> findAllByUserAAndRegion(User user, Long regionId, Pageable pageable);
+
 }

--- a/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/aiverification/store/repository/StoreRepository.java
@@ -18,4 +18,6 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
   Page<Store> findAllByStatus(Boolean status, Pageable pageable);
   Page<Store> findAllByCategoryAndStatus(Long categoryId, boolean b, Pageable pageable);
   Page<Store> findAllByRegionAndStatus(Long regionId, boolean b, Pageable pageable);
+
+  Store findByMenuId(UUID menuId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#25, #34

## 📝작업 내용
> User(CUSTOMER, OWNER), Admin(MANAGER, MASTER)
> Create, Read, Update, Delete

### 정렬 및 페이징 설정
- Store : getAllStores, getAllStoresByCategoryId, getAllStoresByRegionId
- Menu : getAllMenus, getMenusByStoreId
- AI : getAIList

### 권한에 따른 접근 제한
- Store : CUSTOMER status가 true인 것만 R, OWNER 본인 가게만 CUD, Admin CRUD
- Menu, AI : CUSTOMER status가 true인 것만 R, OWNER 본인 가게만CUD, Admin CRUD
- Category, Region : 조회는 모두 가능, Admin CRUD

## 💬리뷰 요구사항
- 테스트하실 때 권한에 따른 접근제한이 타당한지 확인해주시면 될 것 같습니다. 
- 현재 요구사항 기준 카테고리와 지역은 개수가 많지 않을 것으로 예상되어 페이징을 설정하지 않았습니다. 
- 그리고 AI의 경우, 상품마다 생성될 수 있기 때문에 페이징을 설정하였습니다. 